### PR TITLE
sched/core: update rq clock when asking absolute dl params

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -4015,7 +4015,16 @@ __getparam_dl(struct task_struct *p, struct sched_attr *attr, unsigned int flags
 	attr->sched_priority = p->rt_priority;
 
 	if (flags == 1 && p == current) {
+		struct rq_flags rf;
+		struct rq *rq;
+
+		rq = task_rq_lock(p, &rf);
+
+		sched_clock_tick();
+		update_rq_clock(rq);
 		update_curr_dl(task_rq(p));
+
+		task_rq_unlock(rq, p, &rf);
 
 		/*
 		 * sched_runtime can never be negative because, since this


### PR DESCRIPTION
In order to properly update the sched-deadline remaining runtime, the
runqueue clock has to be updated.